### PR TITLE
Fix http port

### DIFF
--- a/lib/celluloid-http/body_decoder.rb
+++ b/lib/celluloid-http/body_decoder.rb
@@ -1,3 +1,5 @@
+require 'zlib'
+
 class Celluloid::Http::BodyDecoder
 
   class<<self

--- a/lib/celluloid-http/connection.rb
+++ b/lib/celluloid-http/connection.rb
@@ -32,7 +32,7 @@ class Celluloid::Http::Connection
 
   def self.open(host, port = 80)
     connection = self.new
-    connection.open(host, 80)
+    connection.open(host, port)
     connection
   end
 

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class ConnectionTest < TestCase
+
+  def test_static_constructor
+    connection = mock('Connection')
+    connection.expects(:open).with('host',8080)
+    Celluloid::Http::Connection.expects(:new).returns(connection)
+
+    Celluloid::Http::Connection.open('host',8080)
+  end
+end


### PR DESCRIPTION
Having trouble accessing a site on non-standard http port

(zlib test was failing for me without the require in 1.9.3)

Let me know if you have any changes to make this easier to merge.

Thanks for the great gem.
